### PR TITLE
golangci: use github actions

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -2,21 +2,27 @@ name: pull request workflow
 
 on: pull_request
 
+env:
+  GO_VERSION: '1.21'
+
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           stable: 'false'
-          go-version: '>=1.17.0'
+          go-version: ${{ env.GO_VERSION }}
 
-      - name: Lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+      - name: lint
+        uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          version: latest
+          # skip cache because of flaky behaviors
+          skip-build-cache: true
+          skip-pkg-cache: true
 
-          golangci-lint run
   test:
     runs-on: ubuntu-20.04
     steps:
@@ -24,7 +30,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'false'
-          go-version: '>=1.17.0'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: test
         run: go test -v ./...

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -6,6 +6,21 @@ env:
   GO_VERSION: '1.21'
 
 jobs:
+  # Check if there is any dirty change for go mod tidy
+  go-mod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check go mod
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m


### PR DESCRIPTION
This makes use of the - now available - golangci github actions. Hopefully this is going to make things more reliable than the custom implementation currently present.

This also bumps the minimum golang version used in tests.